### PR TITLE
feat: api param 재가공 기능 추가와 response 예외 추가

### DIFF
--- a/src/main/java/com/routy/routyback/common/ApiResponse.java
+++ b/src/main/java/com/routy/routyback/common/ApiResponse.java
@@ -37,4 +37,15 @@ public class ApiResponse<T> {
                 .data(null)
                 .build();
     }
+    
+    // 예외처리
+    public static ApiResponse fromException(Exception e) {
+    	if (e instanceof IllegalArgumentException) {
+            return error(400, "BAD_REQUEST: " + e.getMessage());
+        } else if (e instanceof SecurityException) {
+            return error(401, "UNAUTHORIZED: " + e.getMessage());
+        } else {
+            return error(500, "INTERNAL_SERVER_ERROR: " + e.getMessage());
+        }
+    }
 }

--- a/src/main/java/com/routy/routyback/common/ParamProcessor.java
+++ b/src/main/java/com/routy/routyback/common/ParamProcessor.java
@@ -1,0 +1,37 @@
+package com.routy.routyback.common;
+
+import java.util.Map;
+
+public final class ParamProcessor {
+
+	private ParamProcessor() { } // 인스턴스 방지
+
+	public static void paging(Map<String, Object> params) {
+        int page = parseInt(params.get("page"), 1); // int 변환 실패시 1 유지
+        int pageGap = parseInt(params.get("page_gap"), 10); // int 변환 실패시 10유지
+
+        int offset = (page - 1) * pageGap;
+        params.put("offset", String.valueOf(offset));
+        params.put("limit", String.valueOf(pageGap));
+    }
+	
+	public static void likeBothString(Map<String, Object> params, String key) {
+        if (params.containsKey(key)) {
+            Object value = params.get(key);
+            if (value != null) {
+                params.put(key, "%" + value.toString() + "%");
+            }
+        }
+    }
+
+
+
+	private static int parseInt(Object value, int defaultValue) {
+        try {
+            return value != null ? Integer.parseInt(value.toString()) : defaultValue;
+        } catch (NumberFormatException e) {
+            return defaultValue;
+        }
+    }
+
+}

--- a/src/main/java/com/routy/routyback/controller/admin/OrderAdmController.java
+++ b/src/main/java/com/routy/routyback/controller/admin/OrderAdmController.java
@@ -1,20 +1,22 @@
 package com.routy.routyback.controller.admin;
 
-import com.routy.routyback.service.admin.OrderAdmService;
 import java.util.Map;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.routy.routyback.common.ApiResponse;
+import com.routy.routyback.service.admin.OrderAdmService;
+
 @RestController
 public class OrderAdmController {
-
-    @Autowired
-    OrderAdmService service;
-
-    @GetMapping("/orders/list")
-    public Map<String, Object> listAllOrders(@RequestParam Map<String, Object> params) {
-        return service.listAllOrders(params);
-    }
+	@Autowired
+	OrderAdmService service;
+	
+	@GetMapping("/api/orders/list")
+	public ApiResponse listAllOrders(@RequestParam Map<String, Object> params) {
+		return service.listAllOrders(params);
+	}
 }

--- a/src/main/java/com/routy/routyback/service/admin/IOrderAdmService.java
+++ b/src/main/java/com/routy/routyback/service/admin/IOrderAdmService.java
@@ -2,6 +2,8 @@ package com.routy.routyback.service.admin;
 
 import java.util.Map;
 
+import com.routy.routyback.common.ApiResponse;
+
 public interface IOrderAdmService {
-	Map<String, Object> listAllOrders(Map<String, Object> params); // 전체 주문 조회
+	ApiResponse listAllOrders(Map<String, Object> params); // 전체 주문 조회
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #34 

## 📝작업 내용
> 1. 서비스에서 DAO로 파라미터를 넘기기 전 페이지네이션 추가할 수 있도록 파라미터 재가공 하는 기능을 추가하였습니다.
> common/ParamProcessor
> 2. 하기 api 응답 예시처럼 결과값을 쉽게 반환할 수 있도록 common/ApiResponse에 예외값 처리를 추가하였습니다.
> ### 성공응답
> <img width="413" height="300" alt="image" src="https://github.com/user-attachments/assets/d7234d01-59ba-4e0b-a704-685dbd5e8a5c" />
> 
> ### 실패응답
> <img width="439" height="230" alt="image" src="https://github.com/user-attachments/assets/90e4b811-b26e-4f13-b35e-916058b7d747" />

## 💬리뷰 요구사항(선택)

> 확인하시구 더 좋은 구조가 생각나시면 언제든 제안주세요! 0ㅅ0b