### PR TITLE
[feat] 삭제 확인 완료

### DIFF
--- a/src/main/java/com/routy/routyback/mapper/admin/ProductMapper.java
+++ b/src/main/java/com/routy/routyback/mapper/admin/ProductMapper.java
@@ -30,7 +30,8 @@ public interface ProductMapper {
 
     // 삭제
     void productDelete(int prdNo);
-
+    // 상품 상세정보 삭제
+    void deleteProductDetail(int prdNo);
     // 재고 수정
     void productUpdateStock(int prdNo, int prdStock);
 

--- a/src/main/java/com/routy/routyback/service/admin/ProductService.java
+++ b/src/main/java/com/routy/routyback/service/admin/ProductService.java
@@ -47,7 +47,7 @@ public class ProductService implements IProductService {
     }
 
     @Override
-    public String insertProduct(ProductDTO prdDto, ProductDetailDTO prdDetDto) {
+    public String insertProduct(ProductDTO prdDto, ProductDetailDTO prdDetDto) { //상품 추가
     	// 상품정보 등록
     	productMapper.productInsert(prdDto);
     	int prdNo = prdDto.getPrdNo();
@@ -87,6 +87,7 @@ public class ProductService implements IProductService {
     @Override
     @Transactional
     public void deleteProduct(int prdNo) {
+        productMapper.deleteProductDetail(prdNo);
         productMapper.deleteProductIngredientMapping(prdNo); // 1) 매핑 삭제
         productMapper.productDelete(prdNo);                   // 2) 상품 삭제
     }

--- a/src/main/resources/mapper/admin/ProductMapper.xml
+++ b/src/main/resources/mapper/admin/ProductMapper.xml
@@ -115,6 +115,12 @@
         WHERE PRDNO = #{prdNo}
     </delete>
 
+    <!-- 상품 상세정보 삭제 -->
+    <delete id="deleteProductDetail" parameterType="int">
+        DELETE FROM PRODUCT_DETAIL
+        WHERE PRDNO = #{prdNo}
+    </delete>
+
     <!-- 재고 업데이트 -->
     <update id="productUpdateStock">
         UPDATE PRODUCT


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #88 

## 상세 내용

> 관리자 페이지에서 상품 삭제 안되던 부분 fix 완료

이유 : PRODUCT_DETAIL이 PRODUCT를 참조하는 FK가 ON DELETE CASCADE가 아닌 NO ACTION으로 설정되어 있어, 부모(PPRODUCT)를 지우면 자식 레코드가 남아 FK 충돌이 발생함.
기존 삭제 로직은 PRODUCT만 삭제하려 했고, PRODUCT_DETAIL을 먼저 삭제하지 않아 FK 제약 오류가 발생했음.
따라서 PRODUCT_DETAIL → PRD_ING_MAPPING → PRODUCT 순서로 삭제하거나, FK를 ON DELETE CASCADE로 변경해야 정상 삭제됨.