### PR TITLE
Feature/#92 ranking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,4 @@ Wallet_*/
 Wallet_ROUTYDB.zip
 secrets/
 API_SPECS.md
+/src/main/resources/static/images/

--- a/src/main/java/com/routy/routyback/RoutyBackApplication.java
+++ b/src/main/java/com/routy/routyback/RoutyBackApplication.java
@@ -3,11 +3,11 @@ package com.routy.routyback;
 import org.mybatis.spring.annotation.MapperScan;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.ComponentScan;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
-@ComponentScan(basePackages = {"com.routy.routyback"})
-@MapperScan(basePackages = {"com.routy.routyback"})
+@EnableScheduling
+@MapperScan(basePackages = {"com.routy.routyback.mapper"})
 public class RoutyBackApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/routy/routyback/config/WebConfig.java
+++ b/src/main/java/com/routy/routyback/config/WebConfig.java
@@ -2,13 +2,22 @@ package com.routy.routyback.config;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 
 /**
  * Web MVC 설정
- * 
+ *
  * CORS 설정은 SecurityConfig에서 처리하므로 여기서는 제거
  */
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        // /images/product/** 요청을 static/images/product 폴더에 매핑
+        registry.addResourceHandler("/images/product/**")
+            .addResourceLocations("classpath:/static/images/product/");
+    }
+
     // CORS 설정 제거 (SecurityConfig에서 처리)
 }

--- a/src/main/java/com/routy/routyback/controller/user/ProductRankingController.java
+++ b/src/main/java/com/routy/routyback/controller/user/ProductRankingController.java
@@ -1,0 +1,88 @@
+package com.routy.routyback.controller.user;
+
+import com.routy.routyback.common.ApiResponse;
+import com.routy.routyback.dto.user.RankingProductResponse;
+import com.routy.routyback.service.user.IProductRankingService;
+import com.routy.routyback.service.user.ProductRankingBatchService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 상품 랭킹 조회 컨트롤러
+ *
+ * - 이제 이 컨트롤러는 “실시간 집계”가 아닌
+ *   PRODUCT_RANKING_CACHE 테이블에서 조회된 데이터를 그대로 반환합니다.
+ *
+ * - 매일 자정(00:00) 배치가 캐시를 갱신하므로
+ *   FE는 매우 빠르고 안정적이며 고정된 랭킹 데이터를 받을 수 있습니다.
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/products")
+public class ProductRankingController {
+
+    // 랭킹 조회 전용 서비스 (캐시 기반)
+    private final IProductRankingService productRankingService;
+    private final ProductRankingBatchService productRankingBatchService;
+
+    // BE에서 static/images/product/** 로 매핑된 기본 이미지 URL prefix
+    private static final String IMG_BASE_URL = "http://localhost:8080/images/product/";
+
+    /**
+     * 상품 랭킹 조회 API
+     *
+     * @param category 카테고리 코드
+     *                 - null 또는 "0"이면 전체 랭킹 조회
+     * @param limit 최대 조회 개수 (기본값 20)
+     * @return 상품 랭킹 리스트 (캐시 기반)
+     */
+    @GetMapping("/ranking")
+    public ApiResponse<List<RankingProductResponse>> getCategoryRanking(
+        @RequestParam(required = false) String category,
+        @RequestParam(defaultValue = "20") int limit
+    ) {
+
+        // 1) 서비스에서 캐시 기반 랭킹 조회
+        List<RankingProductResponse> list = productRankingService.getCategoryRanking(category, limit);
+
+        // 2) 이미지 URL 보정
+        //    - DB에는 파일명만 저장되어 있으므로
+        //      FE가 직접 접근 가능한 full URL 형태로 변환
+        list.forEach(item -> {
+            if (item.getPrdImg() != null && !item.getPrdImg().startsWith("http")) {
+                item.setPrdImg(IMG_BASE_URL + item.getPrdImg());
+            }
+        });
+
+        // 3) API 응답 래핑 후 반환
+        return ApiResponse.success(list);
+    }
+
+    /**
+     * 강제 랭킹 캐시 갱신 API (테스트용)
+     *
+     * - 배치 스케줄러를 기다리지 않고,
+     *   관리자가 직접 요청하여 PRODUCT_RANKING_CACHE 를 갱신할 수 있습니다.
+     *
+     * - 호출 시:
+     *     1) 기존 캐시 삭제
+     *     2) 전체 랭킹 캐시 INSERT
+     *     3) 카테고리별 랭킹 캐시 INSERT
+     *
+     * - 실제 운영에서는 인증 필요하지만,
+     *   개발 단계에서는 편의를 위해 공개해둡니다.
+     */
+    @GetMapping("/ranking/cache/update")
+    public ApiResponse<String> forceUpdateRankingCache() {
+
+        // 1) 캐시 갱신 실행
+        productRankingBatchService.updateRankingCache();
+
+        // 2) FE 확인용 결과 메시지 반환
+        return ApiResponse.success("랭킹 캐시 갱신 완료");
+    }
+}

--- a/src/main/java/com/routy/routyback/dto/user/RankingProductResponse.java
+++ b/src/main/java/com/routy/routyback/dto/user/RankingProductResponse.java
@@ -1,0 +1,31 @@
+package com.routy.routyback.dto.user;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * 판매량 + 랭킹(순위) + 카테고리 필터 기반 DTO
+ * - PRODUCT_RANKING_CACHE 테이블 조회 결과를 그대로 담아 FE 로 전달합니다.
+ */
+@Getter
+@Setter
+public class RankingProductResponse {
+
+    /** 상품 번호 (PRDNO) */
+    private Long prdNo;
+
+    /** 상품명 (PRODUCT.PRDNAME) */
+    private String prdName;
+
+    /** 판매 가격 (PRODUCT.PRDPRICE) */
+    private Integer prdPrice;
+
+    /** 상품 이미지 URL (BE에서 prefix 붙여 full URL로 변환) */
+    private String prdImg;
+
+    /** 총 판매량 (CACHE.SALES) */
+    private Integer sales;
+
+    /** 캐시에서 계산된 순위 (CACHE.RANK_NO) */
+    private Integer rankNo;
+}

--- a/src/main/java/com/routy/routyback/mapper/user/ProductRankingBatchMapper.java
+++ b/src/main/java/com/routy/routyback/mapper/user/ProductRankingBatchMapper.java
@@ -1,0 +1,30 @@
+package com.routy.routyback.mapper.user;
+
+import org.apache.ibatis.annotations.Mapper;
+
+/**
+ * PRODUCT_RANKING_CACHE 테이블을 관리하는 MyBatis Mapper 인터페이스입니다.
+ * - 캐시 삭제
+ * - 전체 랭킹 INSERT
+ * - 카테고리별 랭킹 INSERT
+ */
+@Mapper
+public interface ProductRankingBatchMapper {
+
+    /**
+     * 오늘 날짜의 캐시 데이터를 모두 삭제합니다.
+     * TRUNC(SYSDATE) 기준으로 삭제됩니다.
+     */
+    void deleteTodayCache();
+
+    /**
+     * 전체 인기 상품 랭킹 데이터를 PRODUCT_RANKING_CACHE 테이블에 저장합니다.
+     * 판매량 기준 정렬 후 RANK() OVER 로 순위를 부여합니다.
+     */
+    void insertOverallRankingCache();
+
+    /**
+     * 카테고리별 랭킹 데이터를 PRODUCT_RANKING_CACHE 테이블에 저장합니다.
+     */
+    void insertCategoryRankingCache();
+}

--- a/src/main/java/com/routy/routyback/mapper/user/ProductRankingMapper.java
+++ b/src/main/java/com/routy/routyback/mapper/user/ProductRankingMapper.java
@@ -1,0 +1,25 @@
+package com.routy.routyback.mapper.user;
+
+import com.routy.routyback.dto.user.RankingProductResponse;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
+
+/**
+ * 상품 랭킹 관련 Mapper
+ * 판매량 기반 랭킹 조회 기능만 담당한다.
+ */
+@Mapper
+public interface ProductRankingMapper {
+
+    /**
+     * 판매량 랭킹 조회
+     * @param category 필터용 카테고리 (null 허용)
+     * @param limit 최대 조회 개수
+     */
+    List<RankingProductResponse> getCategoryRanking(
+        @Param("category") String category,
+        @Param("limit") int limit
+    );
+}

--- a/src/main/java/com/routy/routyback/scheduler/ProductRankingScheduler.java
+++ b/src/main/java/com/routy/routyback/scheduler/ProductRankingScheduler.java
@@ -1,0 +1,49 @@
+package com.routy.routyback.scheduler;
+
+import com.routy.routyback.service.user.ProductRankingBatchService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * 상품 랭킹 캐시를 주기적으로 갱신하는 스케줄러 클래스입니다.
+ *
+ * - 매일 정해진 시간(현재 설정: 서버 기준 00:00)에 한 번 실행됩니다.
+ * - 실행 시, ProductRankingBatchService 를 호출하여
+ *   PRODUCT_RANKING_CACHE 테이블을 최신 상태로 다시 계산합니다.
+ */
+@Slf4j                    // 로그 출력용 어노테이션 (log.info(), log.error() 등 사용)
+@Component                // 스프링 빈 등록 (Scheduling 에서 자동으로 감지하여 실행)
+@RequiredArgsConstructor  // final 필드를 파라미터로 받는 생성자를 자동 생성
+public class ProductRankingScheduler {
+
+    /**
+     * 실제 랭킹 캐시를 생성/갱신하는 비즈니스 로직을 담당하는 서비스입니다.
+     * - 배치 로직(DELETE + INSERT)을 이 서비스 안에 모아두고
+     *   스케줄러에서는 "언제 호출할지"만 책임집니다.
+     */
+    private final ProductRankingBatchService productRankingBatchService;
+
+    /**
+     * 매일 서버 기준 00:00 에 실행되는 배치 메서드입니다.
+     *
+     * - cron = "0 0 0 * * ?" 의 의미:
+     *   초   분   시  일  월  요일
+     *   0   0   0   *   *   ?  → 매일 00시 00분 00초
+     *
+     * - 이 메서드는 스케줄러에 의해 자동 호출되며,
+     *   내부에서 랭킹 캐시 테이블을 전부 다시 계산합니다.
+     */
+    @Scheduled(cron = "0 0 7 * * ?")
+    public void updateDailyRankingCache() {
+        // 1) 배치 시작 로그
+        log.info("[ProductRankingScheduler] 매일 07:00 상품 랭킹 캐시 갱신 배치 시작");
+
+        // 2) 랭킹 캐시 갱신 비즈니스 로직 호출
+        productRankingBatchService.updateRankingCache();
+
+        // 3) 배치 종료 로그
+        log.info("[ProductRankingScheduler] 상품 랭킹 캐시 갱신 배치 종료");
+    }
+}

--- a/src/main/java/com/routy/routyback/service/user/IProductRankingBatchService.java
+++ b/src/main/java/com/routy/routyback/service/user/IProductRankingBatchService.java
@@ -1,0 +1,18 @@
+package com.routy.routyback.service.user;
+
+/**
+ * 매일 자정에 실행되는 상품 랭킹 캐시(batch) 작업을 담당하는 서비스 인터페이스입니다.
+ * - 캐시 초기화(삭제)
+ * - 전체 랭킹 계산 후 캐시에 저장
+ * - 카테고리별 랭킹 계산 후 캐시에 저장
+ */
+public interface IProductRankingBatchService {
+
+    /**
+     * 전체 랭킹 캐시를 업데이트하는 주요 배치 메서드입니다.
+     * - 오늘 데이터 삭제
+     * - 전체 랭킹 INSERT
+     * - 카테고리별 랭킹 INSERT
+     */
+    void updateRankingCache();
+}

--- a/src/main/java/com/routy/routyback/service/user/IProductRankingService.java
+++ b/src/main/java/com/routy/routyback/service/user/IProductRankingService.java
@@ -1,0 +1,21 @@
+package com.routy.routyback.service.user;
+
+import com.routy.routyback.dto.user.RankingProductResponse;
+
+import java.util.List;
+
+/**
+ * 상품 랭킹 서비스 인터페이스
+ */
+public interface IProductRankingService {
+
+    /**
+     * 카테고리 + 판매량 기반 랭킹 조회
+     *
+     * @param category 카테고리명 (null 가능)
+     * @param limit 조회 개수 (기본 20)
+     * @return 랭킹 데이터 리스트
+     */
+    List<RankingProductResponse> getCategoryRanking(String category, int limit);
+    
+}

--- a/src/main/java/com/routy/routyback/service/user/ProductRankingBatchService.java
+++ b/src/main/java/com/routy/routyback/service/user/ProductRankingBatchService.java
@@ -1,0 +1,44 @@
+package com.routy.routyback.service.user;
+
+import com.routy.routyback.mapper.user.ProductRankingBatchMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+/**
+ * ProductRankingBatchService 인터페이스의 구현체입니다.
+ * - 랭킹 캐시를 갱신하는 실제 로직이 들어있습니다.
+ */
+@Slf4j // 로그 사용을 위한 어노테이션
+@Service // 스프링 빈 등록
+@RequiredArgsConstructor // final 필드를 자동 DI
+public class ProductRankingBatchService implements IProductRankingBatchService {
+
+    // 배치용 Mapper (DELETE + INSERT)
+    private final ProductRankingBatchMapper productRankingBatchMapper;
+
+    /**
+     * 랭킹 캐시를 갱신하는 메인 로직입니다.
+     * - 오늘 날짜 캐시 삭제
+     * - 전체 랭킹 계산 후 INSERT
+     * - 카테고리별 랭킹 계산 후 INSERT
+     */
+    @Override
+    public void updateRankingCache() {
+
+        // 1) 오늘자 캐시 삭제
+        log.info("[Ranking Batch] 기존 캐시 삭제 시작");
+        productRankingBatchMapper.deleteTodayCache();
+        log.info("[Ranking Batch] 기존 캐시 삭제 완료");
+
+        // 2) 전체 랭킹 캐시 생성
+        log.info("[Ranking Batch] 전체 랭킹 캐시 INSERT 시작");
+        productRankingBatchMapper.insertOverallRankingCache();
+        log.info("[Ranking Batch] 전체 랭킹 캐시 INSERT 완료");
+
+        // 3) 카테고리별 랭킹 캐시 생성
+        log.info("[Ranking Batch] 카테고리별 랭킹 캐시 INSERT 시작");
+        productRankingBatchMapper.insertCategoryRankingCache();
+        log.info("[Ranking Batch] 카테고리별 랭킹 캐시 INSERT 완료");
+    }
+}

--- a/src/main/java/com/routy/routyback/service/user/ProductRankingService.java
+++ b/src/main/java/com/routy/routyback/service/user/ProductRankingService.java
@@ -1,0 +1,52 @@
+package com.routy.routyback.service.user;
+
+import com.routy.routyback.dto.user.RankingProductResponse;
+import com.routy.routyback.mapper.user.ProductRankingMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+/**
+ * 상품 랭킹 조회 서비스입니다.
+ * - 이 서비스는 "실시간 계산"이 아니라,
+ *   배치(Scheduler)를 통해 매일 자정(00:00)에 미리 계산해둔
+ *   PRODUCT_RANKING_CACHE 테이블만 조회합니다.
+ *
+ * - 따라서 FE는 빠르게 고정된 랭킹 데이터를 받을 수 있고,
+ *   대규모 트래픽에도 성능이 안정적입니다.
+ */
+@Service
+@RequiredArgsConstructor
+public class ProductRankingService implements IProductRankingService {
+
+    // 캐시 테이블을 조회하는 Mapper (실시간 SUM 계산 없음)
+    private final ProductRankingMapper productRankingMapper;
+
+    /**
+     * 카테고리별 랭킹 조회 메서드
+     *
+     * @param category 카테고리 코드
+     *                 - null 또는 "0" → 전체 랭킹
+     * @param limit FE가 요청한 최대 반환 개수
+     *              - 0 이하일 경우 기본값 20 적용
+     *
+     * @return RankingProductResponse 리스트 (캐시 기반)
+     */
+    @Override
+    public List<RankingProductResponse> getCategoryRanking(String category, int limit) {
+
+        // limit 기본값 처리
+        if (limit <= 0) {
+            limit = 20; // FE 기본값
+        }
+
+        // category가 비어있으면 null로 통일하여 전체 캐시 조회
+        if (category == null || category.equals("0") || category.isBlank()) {
+            category = null;
+        }
+
+        // 캐시 테이블에서 랭킹 조회
+        return productRankingMapper.getCategoryRanking(category, limit);
+    }
+}

--- a/src/main/resources/mapper/batch/ProductRankingBatchMapper.xml
+++ b/src/main/resources/mapper/batch/ProductRankingBatchMapper.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+    "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<!--
+    PRODUCT_RANKING_CACHE 캐시 갱신용 매퍼 XML
+    - deleteTodayCache : 오늘 날짜 데이터 삭제
+    - insertOverallRankingCache : 전체 랭킹 저장
+    - insertCategoryRankingCache : 카테고리별 랭킹 저장
+-->
+
+<mapper namespace="com.routy.routyback.mapper.user.ProductRankingBatchMapper">
+
+    <!-- ============================================== -->
+    <!-- 1) 오늘 날짜 캐시 삭제                         -->
+    <!-- ============================================== -->
+    <delete id="deleteTodayCache">
+        DELETE
+        FROM PRODUCT_RANKING_CACHE
+        WHERE RANK_DATE = TRUNC(SYSDATE)
+    </delete>
+
+    <!-- ============================================== -->
+    <!-- 2) 전체 랭킹 INSERT (카테고리 NULL)            -->
+    <!-- ============================================== -->
+    <insert id="insertOverallRankingCache">
+        INSERT INTO PRODUCT_RANKING_CACHE (RANK_DATE,
+                                           CATEGORY,
+                                           PRDNO,
+                                           SALES,
+                                           RANK_NO)
+        SELECT TRUNC(SYSDATE)                                         AS RANK_DATE, -- 오늘 날짜
+               '0'                                                    AS CATEGORY,  -- 전체 랭킹(카테고리 없음) → NOT NULL 충족
+               p.PRDNO                                                AS PRDNO,     -- 상품 번호
+               NVL(SUM(pp.PPMAPSTOCK), 0)                             AS SALES,     -- 총 판매량
+               RANK() OVER (ORDER BY NVL(SUM(pp.PPMAPSTOCK), 0) DESC) AS RANK_NO
+        FROM PRODUCT p
+                 LEFT JOIN PAY_PRODUCT_MAPPING pp
+                           ON p.PRDNO = pp.PRDNO
+        GROUP BY p.PRDNO
+    </insert>
+
+    <!-- ============================================== -->
+    <!-- 3) 카테고리별 랭킹 INSERT                       -->
+    <!-- ============================================== -->
+    <insert id="insertCategoryRankingCache">
+        INSERT INTO PRODUCT_RANKING_CACHE (RANK_DATE,
+                                           CATEGORY,
+                                           PRDNO,
+                                           SALES,
+                                           RANK_NO)
+        SELECT TRUNC(SYSDATE)             AS RANK_DATE,
+               p.PRDSUBCATE               AS CATEGORY,
+               p.PRDNO                    AS PRDNO,
+               NVL(SUM(pp.PPMAPSTOCK), 0) AS SALES,
+               RANK() OVER (
+                   PARTITION BY p.PRDSUBCATE
+                   ORDER BY NVL(SUM(pp.PPMAPSTOCK), 0) DESC
+                   )                      AS RANK_NO
+        FROM PRODUCT p
+                 LEFT JOIN PAY_PRODUCT_MAPPING pp
+                           ON p.PRDNO = pp.PRDNO
+        WHERE TRIM(p.PRDSUBCATE) IS NOT NULL
+          AND p.PRDSUBCATE &lt;&gt; '0'
+        GROUP BY p.PRDSUBCATE,
+                 p.PRDNO
+    </insert>
+
+</mapper>

--- a/src/main/resources/mapper/user/ProductRankingMapper.xml
+++ b/src/main/resources/mapper/user/ProductRankingMapper.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+    "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.routy.routyback.mapper.user.ProductRankingMapper">
+
+    <!--
+        판매량 + 카테고리 필터 기반 랭킹 조회
+        - 카테고리 지정 시 해당 카테고리만 필터링
+        - 판매량은 PAY_PRODUCT_MAPPING.PPMAPSTOCK 합계
+    -->
+    <select id="getCategoryRanking"
+        resultType="com.routy.routyback.dto.user.RankingProductResponse">
+
+        SELECT
+        c.PRDNO AS prdNo,          <!-- 캐시된 상품 번호 -->
+        p.PRDNAME AS prdName,        <!-- 상품명 -->
+        p.PRDPRICE AS prdPrice,       <!-- 상품 가격 -->
+        p.PRDIMG AS prdImg,         <!-- 상품 이미지 파일명 -->
+        c.SALES AS sales,          <!-- 캐시된 판매량 -->
+        c.RANK_NO AS rankNo          <!-- 캐시된 순위 -->
+        FROM PRODUCT_RANKING_CACHE c
+        JOIN PRODUCT p
+        ON p.PRDNO = c.PRDNO            <!-- 상품 상세 정보 Join -->
+        WHERE c.RANK_DATE = TRUNC(SYSDATE)  <!-- 오늘 날짜 캐시만 조회 -->
+        <if test="category != null and category != '0'">
+            AND c.CATEGORY LIKE CONCAT(#{category}, '%')   <!-- 중분류 코드(예: 41)로 소분류 전체 매칭 -->
+        </if>
+        ORDER BY c.RANK_NO                  <!-- 캐시된 순위 기준 정렬 -->
+        FETCH FIRST #{limit} ROWS ONLY
+    </select>
+
+</mapper>

--- a/src/main/resources/mapper/user/ProductRecentRecommendMapper.xml
+++ b/src/main/resources/mapper/user/ProductRecentRecommendMapper.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE mapper
-        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
-        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+    PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+    "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="com.routy.routyback.mapper.user.ProductRecentRecommendMapper">
 
     <select id="selectRecommendedProducts"
-            resultType="com.routy.routyback.dto.ProductRecentRecommendDTO"
-            parameterType="map">
+        resultType="com.routy.routyback.dto.ProductRecentRecommendDTO"
+        parameterType="map">
 
-        SELECT
-        PRDNO      AS prdNo,
-        PRDNAME    AS prdName,
+        SELECT DISTINCT
+        PRDNO AS prdNo,
+        PRDNAME AS prdName,
         PRDCOMPANY AS prdCompany,
-        PRDIMG     AS prdImg
+        PRDIMG AS prdImg
         FROM PRODUCT
         WHERE 1 = 1
 
@@ -36,4 +36,3 @@
     </select>
 
 </mapper>
-


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#92 랭킹 구현

⸻

## 📝 작업 내용

### 1) 상품 랭킹 캐시 기능 추가 (Batch + Service + Mapper)
	•	매일 자정에 전체/카테고리별 상품 랭킹을 캐싱하는 Batch 기능 구현
	•	PRODUCT_RANKING_CACHE 테이블 구조 설계 및 INSERT 로직 구현
	•	MyBatis XML로 전체/카테고리별 랭킹 INSERT 쿼리 작성
	•	PK 충돌/NULL/패딩 문제 해결 및 안정적인 랭킹 캐시 구조 확립
	•	서비스 계층(ProductRankingService)에서 캐시 조회 기능 구현
	•	LIKE CONCAT(category, '%') 조건 적용으로 중분류 선택 시 소분류 전체 랭킹 조회 가능하도록 개선

### 2) 랭킹 API 컨트롤러 추가
	•	/api/products/ranking
	•	전체 랭킹 조회
	•	카테고리별 랭킹 조회
	•	/api/products/ranking/cache/update
	•	캐시 즉시 갱신 테스트용 API 추가

⸻

### 3) 최근 본 상품 중복 제거 기능 추가
	•	동일한 상품이 연속 조회되는 문제 해결
	•	DISTINCT 적용하여 BE 레벨에서 중복 방지
	•	context 유지에 따라 UI 중복 노출 문제 제거

⸻

### 4) 랭킹 이미지 깨짐 문제 해결 (FE/BE 혼합 이슈)
	•	FE가 상세 조회로 prdImg 를 덮어써서 이미지가 사라지는 문제 제거
	•	RankingPage.js 에서 상세 재조회 로직 제거
	•	BE 랭킹 API에서 내려주는 이미지 URL 그대로 사용하도록 구조 개선
	•	WebConfig 에서 static/product 이미지 URL 정상 매핑 확인

⸻
