### PR TITLE
chore: 프론트엔드 URL 환경변수 적용 및 CORS 설정 개선

### DIFF
--- a/src/main/java/com/routy/routyback/config/security/SecurityConfig.java
+++ b/src/main/java/com/routy/routyback/config/security/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.routy.routyback.config.security;
 
 import java.util.Arrays;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -19,6 +20,9 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @Value("${frontend.url}")
+    private String frontendUrl;
 
     public SecurityConfig(JwtAuthenticationFilter jwtAuthenticationFilter) {
         this.jwtAuthenticationFilter = jwtAuthenticationFilter;
@@ -80,7 +84,7 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(Arrays.asList("http://localhost:3000"));
+        configuration.setAllowedOrigins(Arrays.asList(frontendUrl));
         configuration.setAllowedMethods(
             Arrays.asList("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
         configuration.setAllowedHeaders(Arrays.asList("*"));

--- a/src/main/java/com/routy/routyback/controller/auth/AuthController.java
+++ b/src/main/java/com/routy/routyback/controller/auth/AuthController.java
@@ -15,7 +15,6 @@ import java.util.Map;
 @RestController
 @RequestMapping("/api/auth")
 @RequiredArgsConstructor
-@CrossOrigin(origins = "http://localhost:3000")
 public class AuthController {
 
     private final AuthService authService;

--- a/src/main/java/com/routy/routyback/controller/sms/SmsController.java
+++ b/src/main/java/com/routy/routyback/controller/sms/SmsController.java
@@ -12,7 +12,6 @@ import java.util.Map;
 
 @RestController
 @RequestMapping("/api/sms")
-@CrossOrigin(origins = "http://localhost:3000")
 public class SmsController {
 
     private final SmsService smsService;

--- a/src/main/java/com/routy/routyback/controller/user/SkinProfileController.java
+++ b/src/main/java/com/routy/routyback/controller/user/SkinProfileController.java
@@ -9,7 +9,6 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/api/user/skin-profile")
 @RequiredArgsConstructor
-@CrossOrigin(origins = "http://localhost:3000", allowCredentials = "true")
 public class SkinProfileController {
 
     private final SkinProfileService skinProfileService;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,6 +5,10 @@ spring.application.name=routy-back
 server.address=${SERVER_HOST}
 server.port=${SERVER_PORT}
 # ===============================
+# Frontend URL
+# ===============================
+frontend.url=${FRONTEND_URL}
+# ===============================
 # Oracle Database
 # ===============================
 spring.datasource.driver-class-name=oracle.jdbc.OracleDriver


### PR DESCRIPTION
기존에 하드코딩되어 있던 프론트엔드 URL("http://localhost:3000")을 application.properties의 환경변수(frontend.url)로 분리하여 관리하도록 변경했습니다.
- application.properties에 frontend.url 추가
- SecurityConfig, KakaoAuthService 등에서 @Value로 frontend.url 주입받아 사용
- CORS 허용 origin 및 카카오 로그인 리다이렉트 URL에 환경변수 적용
- 컨트롤러(@CrossOrigin)에서 하드코딩된 origin 제거
- 한글 메시지로 예외 및 로그 메시지 통일

환경별로 프론트엔드 주소를 유연하게 관리할 수 있도록 개선하였습니다.