### PR TITLE
[fix]  최근에 본 상품 기반 추천 정책 변경

### DIFF
--- a/src/main/java/com/routy/routyback/controller/user/ProductUserController.java
+++ b/src/main/java/com/routy/routyback/controller/user/ProductUserController.java
@@ -1,82 +1,82 @@
-package com.routy.routyback.controller.user;
+    package com.routy.routyback.controller.user;
 
-import com.routy.routyback.common.ApiResponse;
-import com.routy.routyback.dto.ProductUserDTO;
-import com.routy.routyback.service.user.IProductRecentRecommendService;
-import com.routy.routyback.service.user.IProductUserService;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.web.bind.annotation.*;
+    import com.routy.routyback.common.ApiResponse;
+    import com.routy.routyback.dto.ProductUserDTO;
+    import com.routy.routyback.service.user.IProductRecentRecommendService;
+    import com.routy.routyback.service.user.IProductUserService;
+    import org.springframework.beans.factory.annotation.Autowired;
+    import org.springframework.beans.factory.annotation.Qualifier;
+    import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
-import java.util.Map;
+    import java.util.List;
+    import java.util.Map;
 
-@RestController
-@RequestMapping("/api/products")
-public class ProductUserController {
+    @RestController
+    @RequestMapping("/api/products")
+    public class ProductUserController {
 
-    @Autowired
-    @Qualifier("productUserService")
-    private IProductUserService service;
+        @Autowired
+        @Qualifier("productUserService")
+        private IProductUserService service;
 
-    @Autowired
-    @Qualifier("recent")
-    private IProductRecentRecommendService recommendService;
+        @Autowired
+        @Qualifier("recent")
+        private IProductRecentRecommendService recommendService;
 
-    // 기본 상품 리스트 조회 (필터 가능)
-    @GetMapping("/list")
-    public ApiResponse getProductList(@RequestParam Map<String, Object> params) {
-        return service.getProductList(params);
-    }
-
-
-    @GetMapping("/list/skin_type")
-    public ApiResponse productSkinBased(@RequestParam Map<String, Object> param) {
-        return service.productSkinBased(param);
-    }
-
-    @GetMapping("/list/skin_cate")
-    public ApiResponse productAllSkinCate(@RequestParam Map<String, Object> param) {
-        return service.productAllSkinCate(param);
-    }
-
-    @GetMapping("/list/skin_commend")
-    public ApiResponse productAllSkinCommend(@RequestParam Map<String, Object> param) {
-        return service.productAllSkinCommend(param);
-    }
-
-    @GetMapping("/list/fallback")
-    public ApiResponse getFallbackProducts(@RequestParam int limit) {
-        return service.getFallbackProducts(limit);
-    }
-
-
-    @GetMapping("/list/recent")
-    public ApiResponse getRecommendedProducts(
-            @RequestParam(required = false) Integer userNo,
-            @RequestParam(required = false) Integer subcate,
-            @RequestParam(required = false) String userId
-    ) {
-        return recommendService.getRecommendedProducts(userNo, subcate, userId);
-    }
-
-    @GetMapping("/{prdNo}")
-    public ApiResponse<ProductUserDTO> productDetailView(@PathVariable int prdNo) {
-        try {
-            ProductUserDTO dto = service.productDetailView(prdNo);
-            if (dto == null) {
-                throw new IllegalArgumentException("해당 상품이 존재하지 않습니다.");
-            }
-            return ApiResponse.success(dto);
-        } catch (Exception e) {
-            return ApiResponse.fromException(e);
+        // 기본 상품 리스트 조회 (필터 가능)
+        @GetMapping("/list")
+        public ApiResponse getProductList(@RequestParam Map<String, Object> params) {
+            return service.getProductList(params);
         }
-    }
 
-    @GetMapping("/brand/list")
-    public ApiResponse getBrandList() {
-        List<String> list = service.getBrandList();
-        return ApiResponse.success(list);
-    }
 
-}
+        @GetMapping("/list/skin_type")
+        public ApiResponse productSkinBased(@RequestParam Map<String, Object> param) {
+            return service.productSkinBased(param);
+        }
+
+        @GetMapping("/list/skin_cate")
+        public ApiResponse productAllSkinCate(@RequestParam Map<String, Object> param) {
+            return service.productAllSkinCate(param);
+        }
+
+        @GetMapping("/list/skin_commend")
+        public ApiResponse productAllSkinCommend(@RequestParam Map<String, Object> param) {
+            return service.productAllSkinCommend(param);
+        }
+
+        @GetMapping("/list/fallback")
+        public ApiResponse getFallbackProducts(@RequestParam int limit) {
+            return service.getFallbackProducts(limit);
+        }
+
+
+        @GetMapping("/list/recent")
+        public ApiResponse getRecommendedProducts(
+                @RequestParam(required = false) Integer userNo,
+                @RequestParam(required = false) Integer subcate,
+                @RequestParam(required = false) String userId
+        ) {
+            return recommendService.getRecommendedProducts(userNo, subcate, userId);
+        }
+
+        @GetMapping("/{prdNo}")
+        public ApiResponse<ProductUserDTO> productDetailView(@PathVariable int prdNo) {
+            try {
+                ProductUserDTO dto = service.productDetailView(prdNo);
+                if (dto == null) {
+                    throw new IllegalArgumentException("해당 상품이 존재하지 않습니다.");
+                }
+                return ApiResponse.success(dto);
+            } catch (Exception e) {
+                return ApiResponse.fromException(e);
+            }
+        }
+
+        @GetMapping("/brand/list")
+        public ApiResponse getBrandList() {
+            List<String> list = service.getBrandList();
+            return ApiResponse.success(list);
+        }
+
+    }

--- a/src/main/java/com/routy/routyback/mapper/user/ProductRecentRecommendMapper.java
+++ b/src/main/java/com/routy/routyback/mapper/user/ProductRecentRecommendMapper.java
@@ -11,10 +11,20 @@ public interface ProductRecentRecommendMapper {
 
     // 가장 최근 본 소카테고리 1개
     Integer findLatestSubcate(@Param("userNo") Integer userNo);
-
+    // 가장 최근 본 본카테고리
+    Integer findLatestMaincate(@Param("userNo") Integer userNo);
     // 최근 본 카테고리 기반 추천 4개
     List<ProductRecentRecommendDTO> recommendByLatestSubcate(
             @Param("userNo") Integer userNo,
             @Param("subcate") Integer subcate
     );
+
+    // mainCate 기반 보충 추천
+    List<ProductRecentRecommendDTO> recommendByMaincateSupplement(
+            @Param("userNo") Integer userNo,
+            @Param("maincate") Integer maincate,
+            @Param("excludePrdNos") List<Integer> excludePrdNos,
+            @Param("limit") int limit
+    );
+
 }

--- a/src/main/java/com/routy/routyback/service/user/ProductRecentRecommendService.java
+++ b/src/main/java/com/routy/routyback/service/user/ProductRecentRecommendService.java
@@ -7,48 +7,89 @@ import com.routy.routyback.mapper.user.RecentProductMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service("recent")
 public class ProductRecentRecommendService implements IProductRecentRecommendService {
 
     @Autowired
-    ProductRecentRecommendMapper mapper;
+    private ProductRecentRecommendMapper mapper;
 
     @Autowired
-    RecentProductMapper recentMapper;
+    private RecentProductMapper recentMapper;
 
     @Override
     public ApiResponse getRecommendedProducts(Integer userNo, Integer subcate, String userId) {
 
-        // 1) userNo 없으면 userId → userNo 조회
+        /* =================================================
+         * 1) userNo 보정 (userId → userNo)
+         * ================================================= */
         if (userNo == null && userId != null) {
             Long temp = recentMapper.getUserNoByUserId(userId);
             if (temp != null) {
-                userNo = temp.intValue();   // Integer로 변환
+                userNo = temp.intValue();
             }
         }
 
         if (userNo == null) {
-            return ApiResponse.success(List.of());
+            return ApiResponse.success(Collections.emptyList());
         }
 
-        // 2) subcate 없으면 → 최근 본 상품에서 최신 1개 subcate 가져오기
+        /* =================================================
+         * 2) subCate 보정 (최근 본 상품 기준)
+         * ================================================= */
         if (subcate == null) {
-            Integer latestSub = mapper.findLatestSubcate(userNo);
-            subcate = latestSub;
+            subcate = mapper.findLatestSubcate(userNo);
         }
 
         if (subcate == null) {
-            return ApiResponse.success(List.of());
+            return ApiResponse.success(Collections.emptyList());
         }
 
-        // 3) 추천 상품 조회
-        List<ProductRecentRecommendDTO> list =
+        /* =================================================
+         * 3) 1차 추천 : 최근 본 subCate 기준
+         * ================================================= */
+        List<ProductRecentRecommendDTO> result =
                 mapper.recommendByLatestSubcate(userNo, subcate);
 
-        return ApiResponse.success(list);
+        /* =================================================
+         * 4) 정책 변경 핵심
+         *    - 3개 이하일 경우 mainCate로 보충
+         * ================================================= */
+        if (result.size() < 4) {
+
+            int need = 4 - result.size();
+
+            // 최근 본 상품의 mainCate 조회
+            Integer maincate = mapper.findLatestMaincate(userNo);
+            if (maincate != null && need > 0) {
+
+                // 이미 추천된 상품 번호
+                List<Integer> excludePrdNos = result.stream()
+                        .map(ProductRecentRecommendDTO::getPrdNo)
+                        .collect(Collectors.toList());
+
+                List<ProductRecentRecommendDTO> supplement =
+                        mapper.recommendByMaincateSupplement(
+                                userNo,
+                                maincate,
+                                excludePrdNos,
+                                need
+                        );
+
+                result.addAll(supplement);
+            }
+        }
+
+        /* =================================================
+         * 5) 최대 4개 보장 (안전장치)
+         * ================================================= */
+        if (result.size() > 4) {
+            result = result.subList(0, 4);
+        }
+
+        return ApiResponse.success(result);
     }
 }
-
-

--- a/src/main/resources/mapper/user/ProductRecentRecommendMapper.xml
+++ b/src/main/resources/mapper/user/ProductRecentRecommendMapper.xml
@@ -58,4 +58,65 @@
         FETCH FIRST 4 ROWS ONLY
     </select>
 
+    <!-- 가장 최근 본 상품의 mainCate -->
+    <select id="findLatestMaincate" resultType="int">
+        SELECT P.PRDMAINCATE
+        FROM VIEWED_PRODUCT VP
+                 JOIN PRODUCT P ON P.PRDNO = VP.PRDNO
+        WHERE VP.USERNO = #{userNo}
+        ORDER BY VP.VPREGDATE DESC
+            FETCH FIRST 1 ROW ONLY
+    </select>
+
+    <!-- 3) mainCate 기반 보충 추천 -->
+    <select id="recommendByMaincateSupplement"
+            resultType="com.routy.routyback.dto.ProductRecentRecommendDTO">
+
+        SELECT
+        P.PRDNO       AS prdNo,
+        P.PRDNAME     AS prdName,
+        P.PRDCOMPANY  AS prdCompany,
+        P.PRDIMG      AS prdImg,
+        NVL(R.REVIEWCOUNT, 0) AS reviewCount,
+        NVL(R.AVGRATING, 0)  AS avgRating
+        FROM PRODUCT P
+
+        LEFT JOIN (
+        SELECT
+        PRDNO,
+        COUNT(*) AS reviewCount,
+        ROUND(AVG(REVSTAR),1) AS avgRating
+        FROM REVIEW
+        GROUP BY PRDNO
+        ) R ON R.PRDNO = P.PRDNO
+
+        WHERE P.PRDMAINCATE = #{maincate}
+        AND NVL(R.AVGRATING, 0) >= 3.0
+
+        <!-- 이미 추천된 상품 제외 -->
+        <if test="excludePrdNos != null and excludePrdNos.size() > 0">
+            AND P.PRDNO NOT IN
+            <foreach collection="excludePrdNos" item="id"
+                     open="(" separator="," close=")">
+                #{id}
+            </foreach>
+        </if>
+
+        <!-- 사용자 기피 / 알러지 성분 제외 -->
+        AND NOT EXISTS (
+        SELECT 1
+        FROM PRD_ING_MAPPING PI
+        JOIN USR_ING_MAPPING UI ON UI.INGNO = PI.INGNO
+        WHERE PI.PRDNO = P.PRDNO
+        AND UI.USERNO = #{userNo}
+        AND UI.UIMAPTYPE IN (2, 3)
+        )
+
+        ORDER BY
+        NVL(R.REVIEWCOUNT, 0) DESC,
+        NVL(R.AVGRATING, 0) DESC
+
+        FETCH FIRST #{limit} ROWS ONLY
+    </select>
+
 </mapper>


### PR DESCRIPTION
기존의 정책에서는 소카테고리에 3개의 상품만 있을경우 메인페이지에서 3개밖에 출력되지 않음 

만약 3개 이하일 경우 최근 본 상품의 maincate 에서 추천 상품을 끌어온다.